### PR TITLE
[WIP] added simple support for returning clause type of queries

### DIFF
--- a/src/main/scala/com/augustnagro/magnum/Frag.scala
+++ b/src/main/scala/com/augustnagro/magnum/Frag.scala
@@ -13,6 +13,7 @@ case class Frag(
 ):
   def query[E](using reader: DbCodec[E]): Query[E] = Query(this, reader)
   def update: Update = Update(this)
+  def returning[E](using reader: DbCodec[E]): Returning[E] = Returning(this)
 
 object Frag:
   private val emptyWriter: FragWriter = (_, _) => 0

--- a/src/main/scala/com/augustnagro/magnum/Returning.scala
+++ b/src/main/scala/com/augustnagro/magnum/Returning.scala
@@ -1,0 +1,24 @@
+package com.augustnagro.magnum
+
+import scala.util.{Failure, Success, Using}, Using.Manager
+import java.sql.Statement
+
+case class Returning[E](frag: Frag)(using reader: DbCodec[E]):
+  def run()(using con: DbCon): E =
+    logSql(frag)
+    Manager(use =>
+      val ps = use(
+        con.connection
+          .prepareStatement(frag.sqlString)
+      )
+      frag.writer.write(ps, 1)
+      val hasResults = ps.execute()
+      if hasResults then
+        val rs = use(ps.getResultSet())
+        rs.next()
+        reader.readSingle(rs)
+      else
+        throw SqlException(frag, Exception("No results for RETURNING clause"))
+    ) match
+      case Success(res) => res
+      case Failure(t)   => throw SqlException(frag, t)

--- a/src/test/scala/PgTests.scala
+++ b/src/test/scala/PgTests.scala
@@ -357,6 +357,22 @@ class PgTests extends FunSuite, TestContainersFixtures:
       personRepo.customUpdate(p.id, isAdmin = true)
       assertEquals(personRepo.findById(p.id).get.isAdmin, true)
 
+  test("custom returning a single column"):
+    connect(ds()):
+      val returningQuery =
+        sql"insert into person (first_name, last_name, is_admin) values ('Arton', 'Senna', true) RETURNING id"
+          .returning[Long]
+      val personId = returningQuery.run()
+      assertEquals(personId, 9L)
+
+  test("custom returning multiple columns"):
+    connect(ds()):
+      val returningQuery =
+        sql"insert into person (first_name, last_name, is_admin) values ('Arton', 'Senna', true) RETURNING id, created"
+          .returning[(Long, OffsetDateTime)]
+      val (personId, created) = returningQuery.run()
+      assertEquals(personId, 9L)
+
   @SqlName("person")
   @Table(PostgresDbType, SqlNameMapper.CamelToSnakeCase)
   case class CustomPerson(

--- a/src/test/scala/SqliteTests.scala
+++ b/src/test/scala/SqliteTests.scala
@@ -237,6 +237,14 @@ class SqliteTests extends FunSuite:
         assertEquals(people.size, 3)
         assertEquals(people.last.lastName, newPc.last.lastName)
 
+  test("custom returning"):
+    connect(ds()):
+      val returningQuery =
+        sql"insert into person (first_name, last_name, is_admin) values ('Arton', 'Senna', true) RETURNING id"
+          .returning[Long]
+      val personId = returningQuery.run()
+      assertEquals(personId, 9L)
+
   test("insert invalid"):
     intercept[SqlException]:
       connect(ds()):


### PR DESCRIPTION
This PR is mostly a proposal, hence limited testing. Currently it's not possible to write a custom returning scheme update because `.update` call does not allow it. This PR introduces this capability but it's not refined and probably lacks necessary genericity to work with all databases (that piece of handling is quite different from what I recall and see in Magnum's codebase anyway). A discussion on how to support this would be nice. Maybe it should be done the other way around - via extension methods for `Frag` available in scopes of `DbType` subtype imports?