### PR TITLE
added support for column and table names in repos

### DIFF
--- a/src/main/scala/com/augustnagro/magnum/ClickhouseDbType.scala
+++ b/src/main/scala/com/augustnagro/magnum/ClickhouseDbType.scala
@@ -157,3 +157,11 @@ object ClickhouseDbType extends DbType:
           con: DbCon
       ): BatchUpdateResult =
         throw UnsupportedOperationException()
+
+      def columns: AllColumns = AllColumns.fromSeq(eElemNamesSql)
+
+      def insertColumns: InsertColumns = InsertColumns.fromSeq(ecElemNamesSql)
+
+      def tableName: Repo.TableName = Repo.TableName(tableNameSql)
+
+      def idColumn: Repo.IdColumn = Repo.IdColumn(idName)

--- a/src/main/scala/com/augustnagro/magnum/H2DbType.scala
+++ b/src/main/scala/com/augustnagro/magnum/H2DbType.scala
@@ -237,3 +237,11 @@ object H2DbType extends DbType:
         ) match
           case Success(res) => res
           case Failure(t)   => throw SqlException(updateSql, entities, t)
+
+      def columns: AllColumns = AllColumns.fromSeq(eElemNamesSql)
+
+      def insertColumns: InsertColumns = InsertColumns.fromSeq(ecElemNamesSql)
+
+      def tableName: Repo.TableName = Repo.TableName(tableNameSql)
+
+      def idColumn: Repo.IdColumn = Repo.IdColumn(idName)

--- a/src/main/scala/com/augustnagro/magnum/ImmutableRepo.scala
+++ b/src/main/scala/com/augustnagro/magnum/ImmutableRepo.scala
@@ -35,3 +35,9 @@ open class ImmutableRepo[E, ID](using defaults: RepoDefaults[?, E, ID]):
     */
   def findAllById(ids: Iterable[ID])(using DbCon): Vector[E] =
     defaults.findAllById(ids)
+
+  def * : AllColumns = defaults.columns
+
+  def id: Repo.IdColumn = defaults.idColumn
+
+  def table: Repo.TableName = defaults.tableName

--- a/src/main/scala/com/augustnagro/magnum/MySqlDbType.scala
+++ b/src/main/scala/com/augustnagro/magnum/MySqlDbType.scala
@@ -222,3 +222,11 @@ object MySqlDbType extends DbType:
         ) match
           case Success(res) => res
           case Failure(t)   => throw SqlException(updateSql, entities, t)
+
+      def columns: AllColumns = AllColumns.fromSeq(eElemNamesSql)
+
+      def insertColumns: InsertColumns = InsertColumns.fromSeq(ecElemNamesSql)
+
+      def tableName: Repo.TableName = Repo.TableName(tableNameSql)
+
+      def idColumn: Repo.IdColumn = Repo.IdColumn(idName)

--- a/src/main/scala/com/augustnagro/magnum/OracleDbType.scala
+++ b/src/main/scala/com/augustnagro/magnum/OracleDbType.scala
@@ -206,3 +206,11 @@ object OracleDbType extends DbType:
         ) match
           case Success(res) => res
           case Failure(t)   => throw SqlException(updateSql, entities, t)
+
+      def columns: AllColumns = AllColumns.fromSeq(eElemNamesSql)
+
+      def insertColumns: InsertColumns = InsertColumns.fromSeq(ecElemNamesSql)
+
+      def tableName: Repo.TableName = Repo.TableName(tableNameSql)
+
+      def idColumn: Repo.IdColumn = Repo.IdColumn(idName)

--- a/src/main/scala/com/augustnagro/magnum/PostgresDbType.scala
+++ b/src/main/scala/com/augustnagro/magnum/PostgresDbType.scala
@@ -208,7 +208,7 @@ object PostgresDbType extends DbType:
           ps.executeUpdate()
         ) match
           case Success(_) => ()
-          case Failure(t)   => throw SqlException(updateSql, entity, t)
+          case Failure(t) => throw SqlException(updateSql, entity, t)
 
       def updateAll(entities: Iterable[E])(using
           con: DbCon
@@ -235,3 +235,11 @@ object PostgresDbType extends DbType:
         ) match
           case Success(res) => res
           case Failure(t)   => throw SqlException(updateSql, entities, t)
+
+      def columns: AllColumns = AllColumns.fromSeq(eElemNamesSql)
+
+      def insertColumns: InsertColumns = InsertColumns.fromSeq(ecElemNamesSql)
+
+      def tableName: Repo.TableName = Repo.TableName(tableNameSql)
+
+      def idColumn: Repo.IdColumn = Repo.IdColumn(idName)

--- a/src/main/scala/com/augustnagro/magnum/Renderables.scala
+++ b/src/main/scala/com/augustnagro/magnum/Renderables.scala
@@ -1,0 +1,92 @@
+package com.augustnagro.magnum
+
+import scala.collection.*
+
+// template for all renderables
+
+abstract class Renderables[+SELF <: IndexedSeq[String]](
+    private val strs: IArray[String],
+    private val factory: SpecificIterableFactory[String, SELF]
+) extends IndexedSeq[String],
+      immutable.IndexedSeqOps[String, IndexedSeq, SELF],
+      immutable.StrictOptimizedSeqOps[String, IndexedSeq, SELF]:
+  self: SELF =>
+
+  def length: Int = strs.length
+
+  def apply(idx: Int): String =
+    if idx < 0 || length <= idx then throw new IndexOutOfBoundsException
+    strs(idx)
+
+  // Mandatory overrides of `fromSpecific`, `newSpecificBuilder`,
+  // and `empty`, from `IterableOps`
+  override protected def fromSpecific(coll: IterableOnce[String]): SELF =
+    factory.fromSpecific(coll)
+  override protected def newSpecificBuilder: mutable.Builder[String, SELF] =
+    factory.newBuilder
+  override def empty: SELF = factory.empty
+
+  // Overloading of `appended`, `prepended`, `appendedAll`, `prependedAll`,
+  // `map`, `flatMap` and `concat` to return a `Columns` when possible
+  def concat(suffix: IterableOnce[String]): SELF =
+    strictOptimizedConcat(suffix, newSpecificBuilder)
+  inline final def ++(suffix: IterableOnce[String]): SELF = concat(suffix)
+  def appended(String: String): SELF =
+    (newSpecificBuilder ++= this += String).result()
+  def appendedAll(suffix: Iterable[String]): SELF =
+    strictOptimizedConcat(suffix, newSpecificBuilder)
+  def prepended(String: String): SELF =
+    (newSpecificBuilder += String ++= this).result()
+  def prependedAll(prefix: Iterable[String]): SELF =
+    (newSpecificBuilder ++= prefix ++= this).result()
+  def map(f: String => String): SELF =
+    strictOptimizedMap(newSpecificBuilder, f)
+  def flatMap(f: String => IterableOnce[String]): SELF =
+    strictOptimizedFlatMap(newSpecificBuilder, f)
+
+  override def iterator: Iterator[String] = new AbstractIterator[String]:
+    private var current = 0
+    def hasNext = current < self.length
+    def next(): String =
+      val elem = self(current)
+      current += 1
+      elem
+
+// concrete classes
+
+class AllColumns(private val cols: IArray[String])
+    extends Renderables[AllColumns](cols, AllColumns):
+  override def className = "Columns"
+  override def toString(): String = mkString(", ")
+
+class InsertColumns(private val cols: IArray[String])
+    extends Renderables[InsertColumns](cols, InsertColumns):
+  override def className = "InsertColumns"
+  override def toString(): String = mkString("(", ", ", ")")
+
+// Factories
+
+class RenderablesFactory[A <: Renderables[A]](
+    creator: IterableOnce[String] => A
+) extends SpecificIterableFactory[String, A]:
+
+  def fromSeq(buf: collection.Seq[String]): A =
+    creator(buf)
+  def empty: A = fromSeq(Seq.empty)
+
+  def newBuilder: mutable.Builder[String, A] =
+    mutable.ArrayBuffer.newBuilder[String].mapResult(fromSeq)
+
+  def fromSpecific(it: IterableOnce[String]): A = it match
+    case seq: collection.Seq[String] => fromSeq(seq)
+    case _                           => creator(it)
+
+object AllColumns
+    extends RenderablesFactory[AllColumns](it =>
+      new AllColumns(IArray.from(it))
+    )
+
+object InsertColumns
+    extends RenderablesFactory[InsertColumns](it =>
+      new InsertColumns(IArray.from(it))
+    )

--- a/src/main/scala/com/augustnagro/magnum/Repo.scala
+++ b/src/main/scala/com/augustnagro/magnum/Repo.scala
@@ -52,3 +52,18 @@ open class Repo[EC, E, ID](using defaults: RepoDefaults[EC, E, ID])
   /** Update all entities */
   def updateAll(entities: Iterable[E])(using DbCon): BatchUpdateResult =
     defaults.updateAll(entities)
+
+  def insertColumns: InsertColumns = defaults.insertColumns
+
+object Repo:
+
+  trait Identifier
+
+  opaque type TableName <: Identifier = String & Identifier
+  opaque type IdColumn <: Identifier = String & Identifier
+
+  object TableName:
+    private[magnum] def apply(s: String): TableName = s.asInstanceOf[TableName]
+
+  object IdColumn:
+    private[magnum] def apply(s: String): IdColumn = s.asInstanceOf[IdColumn]

--- a/src/main/scala/com/augustnagro/magnum/RepoDefaults.scala
+++ b/src/main/scala/com/augustnagro/magnum/RepoDefaults.scala
@@ -23,6 +23,11 @@ trait RepoDefaults[EC, E, ID]:
   def insertAllReturning(entityCreators: Iterable[EC])(using DbCon): Vector[E]
   def update(entity: E)(using DbCon): Unit
   def updateAll(entities: Iterable[E])(using DbCon): BatchUpdateResult
+  // metadata to help with query building
+  def columns: AllColumns
+  def insertColumns: InsertColumns
+  def tableName: Repo.TableName
+  def idColumn: Repo.IdColumn
 
 object RepoDefaults:
 
@@ -76,7 +81,7 @@ object RepoDefaults:
                 }
               }) =>
             val tableNameSql = sqlTableNameAnnot[E] match {
-              case Some(sqlName) => 
+              case Some(sqlName) =>
                 '{ $sqlName.name }
               case None =>
                 val tableName = Expr(Type.valueOfConstant[eLabel].get.toString)

--- a/src/main/scala/com/augustnagro/magnum/SqliteDbType.scala
+++ b/src/main/scala/com/augustnagro/magnum/SqliteDbType.scala
@@ -238,3 +238,11 @@ object SqliteDbType extends DbType:
         ) match
           case Success(res) => res
           case Failure(t)   => throw SqlException(updateSql, entities, t)
+
+      def columns: AllColumns = AllColumns.fromSeq(eElemNamesSql)
+
+      def insertColumns: InsertColumns = InsertColumns.fromSeq(ecElemNamesSql)
+
+      def tableName: Repo.TableName = Repo.TableName(tableNameSql)
+
+      def idColumn: Repo.IdColumn = Repo.IdColumn(idName)

--- a/src/test/scala/OracleTests.scala
+++ b/src/test/scala/OracleTests.scala
@@ -29,7 +29,10 @@ class OracleTests extends FunSuite, TestContainersFixtures:
       color: Color
   ) derives DbCodec
 
-  val carRepo = ImmutableRepo[Car, Long]
+  object carRepo extends ImmutableRepo[Car, Long]:
+    def customSelect(using DbCon): Car =
+      val sql = sql"select ${*} from $table where $id = 1"
+      sql.query[Car].run().head
 
   val allCars = Vector(
     Car("McLaren Senna", 1L, 208, Some(123), Color.Red),
@@ -94,7 +97,8 @@ class OracleTests extends FunSuite, TestContainersFixtures:
       val vin = Some(124)
       val cars =
         sql"select * from car where vin = $vin"
-          .query[Car].run()
+          .query[Car]
+          .run()
       assertEquals(cars, allCars.filter(_.vinNumber == vin))
 
   test("tuple select"):
@@ -107,6 +111,10 @@ class OracleTests extends FunSuite, TestContainersFixtures:
   test("reads null int as None and not Some(0)"):
     connect(ds()):
       assertEquals(carRepo.findById(3L).get.vinNumber, None)
+
+  test("custom select"):
+    connect(ds()):
+      assertEquals(carRepo.customSelect, allCars.head)
 
   /*
   Repo Tests
@@ -126,7 +134,15 @@ class OracleTests extends FunSuite, TestContainersFixtures:
       created: OffsetDateTime
   ) derives DbCodec
 
-  val personRepo = Repo[PersonCreator, Person, Long]
+  object personRepo extends Repo[PersonCreator, Person, Long]:
+    def customInsert(p: PersonCreator)(using DbCon): Unit =
+      val sql = sql"insert into $table $insertColumns values ($p)"
+      sql.update.run()
+
+    def customUpdate(personId: Long, isAdmin: "Y" | "N")(using DbCon): Unit =
+      val sql =
+        sql"update $table set is_admin = ${isAdmin: String} where $id = $personId"
+      sql.update.run()
 
   test("delete"):
     connect(ds()):
@@ -311,6 +327,32 @@ class OracleTests extends FunSuite, TestContainersFixtures:
       case _: Exception =>
         transact(dataSource):
           assertEquals(personRepo.count, 8L)
+
+  test("custom insert"):
+    connect(ds()):
+      val p = PersonCreator(
+        firstName = Some("Chandler"),
+        lastName = "Brown",
+        isAdmin = "N"
+      )
+      personRepo.customInsert(p)
+      assertEquals(personRepo.count, 9L)
+      val fetched = personRepo.findAll.last
+      assertEquals(fetched.firstName, p.firstName)
+      assertEquals(fetched.lastName, p.lastName)
+      assertEquals(fetched.isAdmin, p.isAdmin)
+
+  test("custom update"):
+    connect(ds()):
+      val p = personRepo.insertReturning(
+        PersonCreator(
+          firstName = Some("Chandler"),
+          lastName = "Brown",
+          isAdmin = "N"
+        )
+      )
+      personRepo.customUpdate(p.id, isAdmin = "Y")
+      assertEquals(personRepo.findById(1L).get.isAdmin, "Y")
 
   val oracleContainer = ForAllContainerFixture(
     OracleContainer

--- a/src/test/scala/SqliteTests.scala
+++ b/src/test/scala/SqliteTests.scala
@@ -27,7 +27,10 @@ class SqliteTests extends FunSuite:
       color: Color
   ) derives DbCodec
 
-  val carRepo = ImmutableRepo[Car, Long]
+  object carRepo extends ImmutableRepo[Car, Long]:
+    def customSelect(using DbCon): Car =
+      val sql = sql"select ${*} from $table where $id = 1"
+      sql.query[Car].run().head
 
   val allCars = Vector(
     Car("McLaren Senna", 1L, 208, Some(123), Color.Red),
@@ -93,7 +96,8 @@ class SqliteTests extends FunSuite:
       val vin = Some(124)
       val cars =
         sql"select * from car where vin = $vin"
-          .query[Car].run()
+          .query[Car]
+          .run()
       assertEquals(cars, allCars.filter(_.vinNumber == vin))
 
   test("tuple select"):
@@ -106,6 +110,10 @@ class SqliteTests extends FunSuite:
   test("reads null int as None and not Some(0)"):
     connect(ds()):
       assertEquals(carRepo.findById(3L).get.vinNumber, None)
+
+  test("custom select"):
+    connect(ds()):
+      assertEquals(carRepo.customSelect, allCars.head)
 
   /*
   Repo Tests
@@ -125,7 +133,14 @@ class SqliteTests extends FunSuite:
       created: String
   ) derives DbCodec
 
-  val personRepo = Repo[PersonCreator, Person, Long]
+  object personRepo extends Repo[PersonCreator, Person, Long]:
+    def customInsert(p: PersonCreator)(using DbCon): Unit =
+      val sql = sql"insert into $table $insertColumns values ($p)"
+      sql.update.run()
+
+    def customUpdate(personId: Long, isAdmin: Boolean)(using DbCon): Unit =
+      val sql = sql"update $table set is_admin = $isAdmin where $id = $personId"
+      sql.update.run()
 
   test("delete"):
     connect(ds()):
@@ -305,6 +320,32 @@ class SqliteTests extends FunSuite:
       case _: Exception =>
         transact(dataSource):
           assertEquals(personRepo.count, 8L)
+
+  test("custom insert"):
+    connect(ds()):
+      val p = PersonCreator(
+        firstName = Some("Chandler"),
+        lastName = "Brown",
+        isAdmin = false
+      )
+      personRepo.customInsert(p)
+      assertEquals(personRepo.count, 9L)
+      val fetched = personRepo.findAll.last
+      assertEquals(fetched.firstName, p.firstName)
+      assertEquals(fetched.lastName, p.lastName)
+      assertEquals(fetched.isAdmin, p.isAdmin)
+
+  test("custom update"):
+    connect(ds()):
+      val p = personRepo.insertReturning(
+        PersonCreator(
+          firstName = Some("Chandler"),
+          lastName = "Brown",
+          isAdmin = false
+        )
+      )
+      personRepo.customUpdate(p.id, isAdmin = true)
+      assertEquals(personRepo.findById(p.id).get.isAdmin, true)
 
   lazy val sqliteDbPath = Files.createTempFile(null, ".db").toAbsolutePath
 


### PR DESCRIPTION
This PR introduces column names and table name into ImmutableRepo and Repo allowing user to build more future-proof queries (addresses #4). For this to work it was also necessary to modify the logic of `sql` interpolator so that it works in two stages (it was initially considering everything that went into the interpolation as value input to be interpolated into PreparedStatement) - first it interpolates identifiers into the SQL query string and only then, after removing identifier type interpolation values goes to value embedding. I have also found out that despite table entity classes needing `derives DbCodec` it was impossible to use these classes in interpolation so I have fixed that in one breath and now it's completely legit to write `sql"INSERT INTO $table $insertColumns VALUES ($p)"` where `p` is a case class instance for which there's a `DbCodec` instance. This in turn replaces the idea for passing of the parameter strings (useless anyhow, it would require custom handling to properly fire DbCodec on such query anyhow, current solution is safer) mentioned in #4. There are tests for all of the supported databases but I have a M-macbook and can't run Oracle so fingers crossed that it doesn't blow up in CI.