### PR TITLE
fix UTC time for timstamp decoder/encoder

### DIFF
--- a/src/main/scala/com/augustnagro/magnum/DbCodec.scala
+++ b/src/main/scala/com/augustnagro/magnum/DbCodec.scala
@@ -16,6 +16,8 @@ import scala.compiletime.{
 }
 import scala.quoted.*
 import scala.reflect.ClassTag
+import java.util.Calendar
+import java.util.TimeZone
 
 /** Typeclass for JDBC reading & writing.
   */
@@ -181,14 +183,17 @@ object DbCodec:
     def queryRepr: String = "?"
 
   given SqlTimestampCodec: DbCodec[java.sql.Timestamp] with
+    private val tzUTC = Calendar.getInstance(
+      TimeZone.getTimeZone("UTC")
+    )
     val cols: IArray[Int] = IArray(Types.TIMESTAMP)
     def readSingle(rs: ResultSet, pos: Int): java.sql.Timestamp =
-      rs.getTimestamp(pos)
+      rs.getTimestamp(pos, tzUTC)
     def writeSingle(
         t: java.sql.Timestamp,
         ps: PreparedStatement,
         pos: Int
-    ): Unit = ps.setTimestamp(pos, t)
+    ): Unit = ps.setTimestamp(pos, t, tzUTC)
     def queryRepr: String = "?"
 
   given OffsetDateTimeCodec: DbCodec[OffsetDateTime] with


### PR DESCRIPTION
Hi. Today I wrote integration tests for my app. Currently my postgres table have column with type 'timstamp', which means that column have value without timezone info. But when I try insert timestamp value to table I see value +n hours from UTC (in my case it was +3 hours). I think, app should store value in UTC format, because if app will launch on different servers in different regions, we can have a lot of problems with it.  