### PR TITLE
Improve `Transactor` layer provider methods to be more ZIO idiomatic, taking the `DataSource` from the environment

### DIFF
--- a/magnum-zio/src/test/scala/com/augustnagro/magnum/magzio/PgZioTests.scala
+++ b/magnum-zio/src/test/scala/com/augustnagro/magnum/magzio/PgZioTests.scala
@@ -6,7 +6,7 @@ import com.dimafeng.testcontainers.munit.fixtures.TestContainersFixtures
 import munit.{AnyFixture, FunSuite, Location}
 import org.postgresql.ds.PGSimpleDataSource
 import org.testcontainers.utility.DockerImageName
-import zio.{Scope, Unsafe}
+import zio.{Scope, Unsafe, ZLayer}
 
 import java.nio.file.{Files, Path}
 import scala.util.Using
@@ -47,7 +47,12 @@ class PgZioTests extends FunSuite, TestContainersFixtures:
     // todo unsafe
     Unsafe.unsafe { implicit unsafe =>
       zio.Runtime.default.unsafe
-        .run(Transactor.layer(ds).build(Scope.global).map(_.get))
+        .run(
+          Transactor.layer
+            .build(Scope.global)
+            .map(_.get)
+            .provide(ZLayer.succeed(ds))
+        )
         .getOrThrow()
     }
   end xa


### PR DESCRIPTION
@AugustNagro I was trying to migrate my project at work this morning to `2.0.0-M1` and noticed that it wasn't very ZIO idiomatic how we did it. This way is better as the `DataSource` will also be provided in a layer