### PR TITLE
WIP towards tuple n codec

### DIFF
--- a/magnum-zio/src/test/scala/com/augustnagro/magnum/magzio/ImmutableRepoZioTests.scala
+++ b/magnum-zio/src/test/scala/com/augustnagro/magnum/magzio/ImmutableRepoZioTests.scala
@@ -172,6 +172,17 @@ def immutableRepoZioTests(
             .query[(String, Color)]
             .run()
     assert(tuples == Vector(allCars(1).model -> allCars(1).color))
+    
+  test("large tuple select"):
+    val tuples =
+      runIO:
+        xa().connect:
+          sql"select model, color, top_speed, id, vin from car where id = 2"
+            .query[(String, Color, Int, Long, Option[Int])]
+            .run()
+    assert(tuples == Vector(
+      allCars(1).model -> allCars(1).color -> allCars(1).topSpeed -> allCars(1).id -> allCars(1).vinNumber
+    ))
 
   test("reads null int as None and not Some(0)"):
     val maybeCar =

--- a/magnum-zio/src/test/scala/com/augustnagro/magnum/magzio/ImmutableRepoZioTests.scala
+++ b/magnum-zio/src/test/scala/com/augustnagro/magnum/magzio/ImmutableRepoZioTests.scala
@@ -172,17 +172,25 @@ def immutableRepoZioTests(
             .query[(String, Color)]
             .run()
     assert(tuples == Vector(allCars(1).model -> allCars(1).color))
-    
+
+  test("large tuple support does not override hand-rolled Tuple[2-4] codecs"):
+    val tuple2ACodec = summon[DbCodec[(String, Color)]]
+    val tuple2BCodec = summon[DbCodec[(String, Int)]]
+    assert(tuple2ACodec.getClass == tuple2BCodec.getClass)
+    val tuple5ACodec = summon[DbCodec[(String, Color, Int, Long, Option[Int])]]
+    assert(tuple5ACodec.getClass != tuple2ACodec.getClass)
+    val tuple5BCodec = summon[DbCodec[(Int, Int, Int, Long, Option[Int])]]
+    assert(tuple5BCodec.getClass != tuple5ACodec.getClass)
+  
   test("large tuple select"):
-    val tuples =
-      runIO:
-        xa().connect:
-          sql"select model, color, top_speed, id, vin from car where id = 2"
-            .query[(String, Color, Int, Long, Option[Int])]
-            .run()
-    assert(tuples == Vector(
-      allCars(1).model -> allCars(1).color -> allCars(1).topSpeed -> allCars(1).id -> allCars(1).vinNumber
-    ))
+    val tuple = runIO:
+      xa().connect:
+        sql"select model, color, top_speed, id, vin from car where id = 2"
+          .query[(String, Color, Int, Long, Option[Int])]
+          .run()
+          .head
+    val c = allCars(1)
+    assert(tuple == (c.model, c.color, c.topSpeed, c.id, c.vinNumber))
 
   test("reads null int as None and not Some(0)"):
     val maybeCar =

--- a/magnum/src/test/scala/shared/ImmutableRepoTests.scala
+++ b/magnum/src/test/scala/shared/ImmutableRepoTests.scala
@@ -165,4 +165,36 @@ def immutableRepoTests(suite: FunSuite, dbType: DbType, xa: () => Transactor)(
 
     assert(query.sqlString.contains("MyCoord(?)"))
 
+  test("large tuple support does not override hand-rolled Tuple[2-4] codecs"):
+    val tuple2ACodec = summon[DbCodec[(String, Color)]]
+    val tuple2BCodec = summon[DbCodec[(String, Int)]]
+    assert(tuple2ACodec.getClass == tuple2BCodec.getClass)
+    val tuple5ACodec = summon[DbCodec[(String, Color, Int, Long, Option[Int])]]
+    assert(tuple5ACodec.getClass != tuple2ACodec.getClass)
+    val tuple5BCodec = summon[DbCodec[(Int, Int, Int, Long, Option[Int])]]
+    assert(tuple5BCodec.getClass != tuple5ACodec.getClass)
+
+  test("large tuple select"):
+    val tuple = xa().connect:
+      sql"select model, color, top_speed, id, vin from car where id = 2"
+        .query[(String, Color, Int, Long, Option[Int])]
+        .run()
+        .head
+    val c = allCars(1)
+    assert(tuple == (c.model, c.color, c.topSpeed, c.id, c.vinNumber))
+
+  test("large tuple select option"):
+    val tupleA = xa().connect:
+      sql"select model, color, top_speed, id, vin from car where id = 99"
+        .query[Option[(String, Color, Int, Long, Option[Int])]]
+        .run()
+        .head
+    // todo
+//    val tupleB = xa().connect:
+//      sql"select model, color, top_speed, id, vin from car where id = 1"
+//        .query[Option[(String, Color, Int, Long, Option[Int])]]
+//        .run()
+//        .head
+//    assert(tupleA.isEmpty, tupleB.isDefined)
+
 end immutableRepoTests


### PR DESCRIPTION
Forked off of https://github.com/AugustNagro/magnum/pull/127 with the following goals:

1. Don't assume that element codecs only use 1 column in the result set (advance pos += codec.cols.length).
2. Return None if any of the element codecs are None after calling codec.readSingleOption. This follows the behavior of the existing Tuple[2-4]Codecs
3. Add more testing & equivalent testing in core magnum project

Todo:
* Add tests in magnumPg module for (1)
* Add tests with heavy mixing of options and tuples