### PR TITLE
Support composite IDs

### DIFF
--- a/magnum/src/main/scala/com/augustnagro/magnum/ClickhouseDbType.scala
+++ b/magnum/src/main/scala/com/augustnagro/magnum/ClickhouseDbType.scala
@@ -16,7 +16,7 @@ object ClickhouseDbType extends DbType:
       eElemCodecs: Seq[DbCodec[?]],
       ecElemNames: Seq[String],
       ecElemNamesSql: Seq[String],
-      idIndex: Int
+      idIndexes: List[Int]
   )(using
       eCodec: DbCodec[E],
       ecCodec: DbCodec[EC],
@@ -29,20 +29,23 @@ object ClickhouseDbType extends DbType:
       eClassTag.runtimeClass == ecClassTag.runtimeClass,
       "ClickHouse does not support generated keys, so EC must equal E"
     )
-    val idName = eElemNamesSql(idIndex)
+    val idNames = idIndexes.map(eElemNamesSql)
+    val idKeys = idNames.mkString("(", ", ", ")")
     val selectKeys = eElemNamesSql.mkString(", ")
     val ecInsertKeys = ecElemNamesSql.mkString("(", ", ", ")")
+    val eElemNamesAndCodecs = eElemNamesSql.lazyZip(eElemCodecs)
+    val idFilter = idKeys + " = " + idCodec.queryRepr
 
     val countSql = s"SELECT count(*) FROM $tableNameSql"
     val countQuery = Frag(countSql, Vector.empty, FragWriter.empty).query[Long]
     val existsByIdSql =
-      s"SELECT 1 FROM $tableNameSql WHERE $idName = ${idCodec.queryRepr}"
+      s"SELECT 1 FROM $tableNameSql WHERE $idFilter"
     val findAllSql = s"SELECT $selectKeys FROM $tableNameSql"
     val findAllQuery = Frag(findAllSql, Vector.empty, FragWriter.empty).query[E]
     val findByIdSql =
-      s"SELECT $selectKeys FROM $tableNameSql WHERE $idName = ${idCodec.queryRepr}"
+      s"SELECT $selectKeys FROM $tableNameSql WHERE $idFilter"
     val deleteByIdSql =
-      s"DELETE FROM $tableNameSql WHERE $idName = ${idCodec.queryRepr}"
+      s"DELETE FROM $tableNameSql WHERE $idFilter"
     val truncateSql = s"TRUNCATE TABLE $tableNameSql"
     val truncateUpdate =
       Frag(truncateSql, Vector.empty, FragWriter.empty).update
@@ -52,6 +55,12 @@ object ClickhouseDbType extends DbType:
     def idWriter(id: ID): FragWriter = (ps, pos) =>
       idCodec.writeSingle(id, ps, pos)
       pos + idCodec.cols.length
+
+    def entityId(entity: E): ID =
+      val idElems = idIndexes.map(entity.asInstanceOf[Product].productElement)
+      idElems match
+        case head :: Nil => head.asInstanceOf[ID]
+        case _ => idClassTag.runtimeClass.getDeclaredConstructors().head.newInstance(idElems*).asInstanceOf[ID]
 
     new RepoDefaults[EC, E, ID]:
       def count(using con: DbCon): Long = countQuery.run().head
@@ -77,12 +86,7 @@ object ClickhouseDbType extends DbType:
         throw UnsupportedOperationException()
 
       def delete(entity: E)(using DbCon): Unit =
-        deleteById(
-          entity
-            .asInstanceOf[Product]
-            .productElement(idIndex)
-            .asInstanceOf[ID]
-        )
+        deleteById(entityId(entity))
 
       def deleteById(id: ID)(using DbCon): Unit =
         Frag(deleteByIdSql, IArray(id), idWriter(id)).update
@@ -93,9 +97,7 @@ object ClickhouseDbType extends DbType:
 
       def deleteAll(entities: Iterable[E])(using DbCon): BatchUpdateResult =
         deleteAllById(
-          entities.map(e =>
-            e.asInstanceOf[Product].productElement(idIndex).asInstanceOf[ID]
-          )
+          entities.map(entityId)
         )
 
       def deleteAllById(ids: Iterable[ID])(using

--- a/magnum/src/main/scala/com/augustnagro/magnum/DbType.scala
+++ b/magnum/src/main/scala/com/augustnagro/magnum/DbType.scala
@@ -12,7 +12,7 @@ trait DbType:
       eElemCodecs: Seq[DbCodec[?]],
       ecElemNames: Seq[String],
       ecElemNamesSql: Seq[String],
-      idIndex: Int
+      idIndexes: List[Int]
   )(using
       eCodec: DbCodec[E],
       ecCodec: DbCodec[EC],

--- a/magnum/src/main/scala/com/augustnagro/magnum/H2DbType.scala
+++ b/magnum/src/main/scala/com/augustnagro/magnum/H2DbType.scala
@@ -16,7 +16,7 @@ object H2DbType extends DbType:
       eElemCodecs: Seq[DbCodec[?]],
       ecElemNames: Seq[String],
       ecElemNamesSql: Seq[String],
-      idIndex: Int
+      idIndexes: List[Int]
   )(using
       eCodec: DbCodec[E],
       ecCodec: DbCodec[EC],
@@ -25,41 +25,46 @@ object H2DbType extends DbType:
       ecClassTag: ClassTag[EC],
       idClassTag: ClassTag[ID]
   ): RepoDefaults[EC, E, ID] =
-    val idName = eElemNamesSql(idIndex)
+    val idNames = idIndexes.map(eElemNamesSql)
+    val idKeys = idNames.mkString("(", ", ", ")")
     val selectKeys = eElemNamesSql.mkString(", ")
     val ecInsertKeys = ecElemNamesSql.mkString("(", ", ", ")")
 
-    val updateKeys: String = eElemNamesSql
-      .lazyZip(eElemCodecs)
+    val eElemNamesAndCodecs = eElemNamesSql.lazyZip(eElemCodecs)
+    val (idNamesAndCodecs, ecNamesAndCodecs) =
+      eElemNamesAndCodecs.partition((sqlName, _) => idNames.contains(sqlName))
+
+    val idFilter = idKeys + " = " + idCodec.queryRepr
+
+    val updateKeys: String = ecNamesAndCodecs
       .map((sqlName, codec) => sqlName + " = " + codec.queryRepr)
-      .patch(idIndex, Seq.empty, 1)
       .mkString(", ")
 
-    val updateCodecs = eElemCodecs
-      .patch(idIndex, Seq.empty, 1)
-      .appended(idCodec)
-      .asInstanceOf[Seq[DbCodec[Any]]]
+    val updateCodecs =
+      (ecNamesAndCodecs.map(_._2) ++ idNamesAndCodecs.map(_._2))
+        .toSeq
+        .asInstanceOf[Seq[DbCodec[Any]]]
 
     val insertGenKeys: Array[String] = Array.from(eElemNamesSql)
 
     val countSql = s"SELECT count(*) FROM $tableNameSql"
     val countQuery = Frag(countSql, Vector.empty, FragWriter.empty).query[Long]
     val existsByIdSql =
-      s"SELECT 1 FROM $tableNameSql WHERE $idName = ${idCodec.queryRepr}"
+      s"SELECT 1 FROM $tableNameSql WHERE $idFilter"
     val findAllSql = s"SELECT * FROM $tableNameSql"
     val findAllQuery = Frag(findAllSql, Vector.empty, FragWriter.empty).query[E]
     val findByIdSql =
-      s"SELECT * FROM $tableNameSql WHERE $idName = ${idCodec.queryRepr}"
-    val findAllByIdSql = s"SELECT * FROM $tableNameSql WHERE $idName = ANY(?)"
+      s"SELECT * FROM $tableNameSql WHERE $idFilter"
+    val findAllByIdSql = s"SELECT * FROM $tableNameSql WHERE $idKeys = ANY(?)"
     val deleteByIdSql =
-      s"DELETE FROM $tableNameSql WHERE $idName = ${idCodec.queryRepr}"
+      s"DELETE FROM $tableNameSql WHERE $idFilter"
     val truncateSql = s"TRUNCATE TABLE $tableNameSql"
     val truncateUpdate =
       Frag(truncateSql, Vector.empty, FragWriter.empty).update
     val insertSql =
       s"INSERT INTO $tableNameSql $ecInsertKeys VALUES (${ecCodec.queryRepr})"
     val updateSql =
-      s"UPDATE $tableNameSql SET $updateKeys WHERE $idName = ${idCodec.queryRepr}"
+      s"UPDATE $tableNameSql SET $updateKeys WHERE $idFilter"
 
     val compositeId = idCodec.cols.distinct.size != 1
     val idFirstTypeName = JDBCType.valueOf(idCodec.cols.head).getName
@@ -67,6 +72,12 @@ object H2DbType extends DbType:
     def idWriter(id: ID): FragWriter = (ps, pos) =>
       idCodec.writeSingle(id, ps, pos)
       pos + idCodec.cols.length
+
+    def entityId(entity: E): ID =
+      val idElems = idIndexes.map(entity.asInstanceOf[Product].productElement)
+      idElems match
+        case head :: Nil => head.asInstanceOf[ID]
+        case _ => idClassTag.runtimeClass.getDeclaredConstructors().head.newInstance(idElems*).asInstanceOf[ID]
 
     new RepoDefaults[EC, E, ID]:
       def count(using con: DbCon): Long = countQuery.run().head
@@ -111,12 +122,7 @@ object H2DbType extends DbType:
 //        Sql(findAllByIdSql, Vector(builder.result())).run
 
       def delete(entity: E)(using DbCon): Unit =
-        deleteById(
-          entity
-            .asInstanceOf[Product]
-            .productElement(idIndex)
-            .asInstanceOf[ID]
-        )
+        deleteById(entityId(entity))
 
       def deleteById(id: ID)(using DbCon): Unit =
         Frag(deleteByIdSql, IArray(id), idWriter(id)).update.run()
@@ -125,9 +131,7 @@ object H2DbType extends DbType:
 
       def deleteAll(entities: Iterable[E])(using DbCon): BatchUpdateResult =
         deleteAllById(
-          entities.map(e =>
-            e.asInstanceOf[Product].productElement(idIndex).asInstanceOf[ID]
-          )
+          entities.map(entityId)
         )
 
       def deleteAllById(ids: Iterable[ID])(using
@@ -183,9 +187,9 @@ object H2DbType extends DbType:
               .productIterator
               .toVector
             // put ID at the end
-            val updateValues = entityValues
-              .patch(idIndex, Vector.empty, 1)
-              .appended(entityValues(idIndex))
+            val (idValues, ecValues) = entityValues.zipWithIndex
+              .partition((_, index) => idIndexes.contains(index))
+            val updateValues = ecValues.map(_._1) ++ idValues.map(_._1)
 
             var pos = 1
             for (field, codec) <- updateValues.lazyZip(updateCodecs) do
@@ -204,9 +208,9 @@ object H2DbType extends DbType:
                 .productIterator
                 .toVector
               // put ID at the end
-              val updateValues = entityValues
-                .patch(idIndex, Vector.empty, 1)
-                .appended(entityValues(idIndex))
+              val (idValues, ecValues) = entityValues.zipWithIndex
+                .partition((_, index) => idIndexes.contains(index))
+              val updateValues = ecValues.map(_._1) ++ idValues.map(_._1)
 
               var pos = 1
               for (field, codec) <- updateValues.lazyZip(updateCodecs) do
@@ -215,7 +219,6 @@ object H2DbType extends DbType:
               ps.addBatch()
 
             timed(batchUpdateResult(ps.executeBatch()))
-
     end new
   end buildRepoDefaults
 end H2DbType

--- a/magnum/src/main/scala/com/augustnagro/magnum/MySqlDbType.scala
+++ b/magnum/src/main/scala/com/augustnagro/magnum/MySqlDbType.scala
@@ -41,7 +41,7 @@ object MySqlDbType extends DbType:
       eElemCodecs: Seq[DbCodec[?]],
       ecElemNames: Seq[String],
       ecElemNamesSql: Seq[String],
-      idIndex: Int
+      idIndexes: List[Int]
   )(using
       eCodec: DbCodec[E],
       ecCodec: DbCodec[EC],
@@ -50,45 +50,61 @@ object MySqlDbType extends DbType:
       ecClassTag: ClassTag[EC],
       idClassTag: ClassTag[ID]
   ): RepoDefaults[EC, E, ID] =
-    val idName = eElemNamesSql(idIndex)
+    val idNames = idIndexes.map(eElemNamesSql)
+    val idKeys = idNames.mkString("(", ", ", ")")
     val selectKeys = eElemNamesSql.mkString(", ")
     val ecInsertKeys = ecElemNamesSql.mkString("(", ", ", ")")
 
-    val insertGenKeys = Array(idName)
+    val insertGenKeys = idNames
 
-    val updateKeys: String = eElemNamesSql
-      .lazyZip(eElemCodecs)
+    val eElemNamesAndCodecs = eElemNamesSql.lazyZip(eElemCodecs)
+    val (idNamesAndCodecs, ecNamesAndCodecs) =
+      eElemNamesAndCodecs.partition((sqlName, _) => idNames.contains(sqlName))
+
+    val idFilter = idKeys + " = " + idCodec.queryRepr
+
+    val updateKeys: String = ecNamesAndCodecs
       .map((sqlName, codec) => sqlName + " = " + codec.queryRepr)
-      .patch(idIndex, Seq.empty, 1)
       .mkString(", ")
 
-    val updateCodecs = eElemCodecs
-      .patch(idIndex, Seq.empty, 1)
-      .appended(idCodec)
-      .asInstanceOf[Seq[DbCodec[Any]]]
+    val updateCodecs =
+      (ecNamesAndCodecs.map(_._2) ++ idNamesAndCodecs.map(_._2))
+        .toSeq
+        .asInstanceOf[Seq[DbCodec[Any]]]
 
     val countSql = s"SELECT count(*) FROM $tableNameSql"
     val countQuery = Frag(countSql, Vector.empty, FragWriter.empty).query[Long]
     val existsByIdSql =
-      s"SELECT 1 FROM $tableNameSql WHERE $idName = ${idCodec.queryRepr}"
+      s"SELECT 1 FROM $tableNameSql WHERE $idFilter"
     val findAllSql = s"SELECT * FROM $tableNameSql"
     val findAllQuery = Frag(findAllSql, Vector.empty, FragWriter.empty).query[E]
     val findByIdSql =
-      s"SELECT * FROM $tableNameSql WHERE $idName = ${idCodec.queryRepr}"
+      s"SELECT * FROM $tableNameSql WHERE $idFilter"
     val deleteByIdSql =
-      s"DELETE FROM $tableNameSql WHERE $idName = ${idCodec.queryRepr}"
+      s"DELETE FROM $tableNameSql WHERE $idFilter"
     val truncateSql = s"TRUNCATE TABLE $tableNameSql"
     val truncateUpdate =
       Frag(truncateSql, Vector.empty, FragWriter.empty).update
     val insertSql =
       s"INSERT INTO $tableNameSql $ecInsertKeys VALUES (${ecCodec.queryRepr})"
     val updateSql =
-      s"UPDATE $tableNameSql SET $updateKeys WHERE $idName = ${idCodec.queryRepr}"
+      s"UPDATE $tableNameSql SET $updateKeys WHERE $idFilter"
     val insertAndFindByIdSql = insertSql + "\n" + findByIdSql
 
     def idWriter(id: ID): FragWriter = (ps, pos) =>
       idCodec.writeSingle(id, ps, pos)
       pos + idCodec.cols.length
+
+    def entityId(entity: E): ID =
+      val idElems = idIndexes.map(entity.asInstanceOf[Product].productElement)
+      idElems match
+        case head :: Nil => head.asInstanceOf[ID]
+        case _ =>
+          idClassTag.runtimeClass
+            .getDeclaredConstructors()
+            .head
+            .newInstance(idElems*)
+            .asInstanceOf[ID]
 
     new RepoDefaults[EC, E, ID]:
       def count(using con: DbCon): Long = countQuery.run().head
@@ -116,12 +132,7 @@ object MySqlDbType extends DbType:
         )
 
       def delete(entity: E)(using DbCon): Unit =
-        deleteById(
-          entity
-            .asInstanceOf[Product]
-            .productElement(idIndex)
-            .asInstanceOf[ID]
-        )
+        deleteById(entityId(entity))
 
       def deleteById(id: ID)(using DbCon): Unit =
         Frag(deleteByIdSql, IArray(id), idWriter(id)).update
@@ -131,9 +142,7 @@ object MySqlDbType extends DbType:
 
       def deleteAll(entities: Iterable[E])(using DbCon): BatchUpdateResult =
         deleteAllById(
-          entities.map(e =>
-            e.asInstanceOf[Product].productElement(idIndex).asInstanceOf[ID]
-          )
+          entities.map(entityId)
         )
 
       def deleteAllById(ids: Iterable[ID])(using
@@ -175,10 +184,9 @@ object MySqlDbType extends DbType:
               .productIterator
               .toVector
             // put ID at the end
-            val updateValues = entityValues
-              .patch(idIndex, Vector.empty, 1)
-              .appended(entityValues(idIndex))
-
+            val (idValues, ecValues) = entityValues.zipWithIndex
+              .partition((_, index) => idIndexes.contains(index))
+            val updateValues = ecValues.map(_._1) ++ idValues.map(_._1)
             var pos = 1
             for (field, codec) <- updateValues.lazyZip(updateCodecs) do
               codec.writeSingle(field, ps, pos)
@@ -196,9 +204,9 @@ object MySqlDbType extends DbType:
                 .productIterator
                 .toVector
               // put ID at the end
-              val updateValues = entityValues
-                .patch(idIndex, Vector.empty, 1)
-                .appended(entityValues(idIndex))
+              val (idValues, ecValues) = entityValues.zipWithIndex
+                .partition((_, index) => idIndexes.contains(index))
+              val updateValues = ecValues.map(_._1) ++ idValues.map(_._1)
 
               var pos = 1
               for (field, codec) <- updateValues.lazyZip(updateCodecs) do

--- a/magnum/src/main/scala/com/augustnagro/magnum/OracleDbType.scala
+++ b/magnum/src/main/scala/com/augustnagro/magnum/OracleDbType.scala
@@ -28,7 +28,7 @@ object OracleDbType extends DbType:
       eElemCodecs: Seq[DbCodec[?]],
       ecElemNames: Seq[String],
       ecElemNamesSql: Seq[String],
-      idIndex: Int
+      idIndexes: List[Int]
   )(using
       eCodec: DbCodec[E],
       ecCodec: DbCodec[EC],
@@ -37,44 +37,55 @@ object OracleDbType extends DbType:
       ecClassTag: ClassTag[EC],
       idClassTag: ClassTag[ID]
   ): RepoDefaults[EC, E, ID] =
-    val idName = eElemNamesSql(idIndex)
+    val idNames = idIndexes.map(eElemNamesSql)
+    val idKeys = idNames.mkString("(", ", ", ")")
     val selectKeys = eElemNamesSql.mkString(", ")
     val ecInsertKeys = ecElemNamesSql.mkString("(", ", ", ")")
 
-    val updateKeys: String = eElemNamesSql
-      .lazyZip(eElemCodecs)
+    val eElemNamesAndCodecs = eElemNamesSql.lazyZip(eElemCodecs)
+    val (idNamesAndCodecs, ecNamesAndCodecs) =
+      eElemNamesAndCodecs.partition((sqlName, _) => idNames.contains(sqlName))
+
+    val idFilter = idKeys + " = " + idCodec.queryRepr
+
+    val updateKeys: String = ecNamesAndCodecs
       .map((sqlName, codec) => sqlName + " = " + codec.queryRepr)
-      .patch(idIndex, Seq.empty, 1)
       .mkString(", ")
 
-    val updateCodecs = eElemCodecs
-      .patch(idIndex, Seq.empty, 1)
-      .appended(idCodec)
-      .asInstanceOf[Seq[DbCodec[Any]]]
+    val updateCodecs =
+      (ecNamesAndCodecs.map(_._2) ++ idNamesAndCodecs.map(_._2))
+        .toSeq
+        .asInstanceOf[Seq[DbCodec[Any]]]
 
     val insertGenKeys = Array.from(eElemNamesSql)
 
     val countSql = s"SELECT count(*) FROM $tableNameSql"
     val countQuery = Frag(countSql, Vector.empty, FragWriter.empty).query[Long]
     val existsByIdSql =
-      s"SELECT 1 FROM $tableNameSql WHERE $idName = ${idCodec.queryRepr}"
+      s"SELECT 1 FROM $tableNameSql WHERE $idFilter"
     val findAllSql = s"SELECT * FROM $tableNameSql"
     val findAllQuery = Frag(findAllSql, Vector.empty, FragWriter.empty).query[E]
     val findByIdSql =
-      s"SELECT * FROM $tableNameSql WHERE $idName = ${idCodec.queryRepr}"
+      s"SELECT * FROM $tableNameSql WHERE $idFilter"
     val deleteByIdSql =
-      s"DELETE FROM $tableNameSql WHERE $idName = ${idCodec.queryRepr}"
+      s"DELETE FROM $tableNameSql WHERE $idFilter"
     val truncateSql = s"TRUNCATE TABLE $tableNameSql"
     val truncateUpdate =
       Frag(truncateSql, Vector.empty, FragWriter.empty).update
     val insertSql =
       s"INSERT INTO $tableNameSql $ecInsertKeys VALUES (${ecCodec.queryRepr})"
     val updateSql =
-      s"UPDATE $tableNameSql SET $updateKeys WHERE $idName = ${idCodec.queryRepr}"
+      s"UPDATE $tableNameSql SET $updateKeys WHERE $idFilter"
 
     def idWriter(id: ID): FragWriter = (ps, pos) =>
       idCodec.writeSingle(id, ps, pos)
       pos + idCodec.cols.length
+
+    def entityId(entity: E): ID =
+      val idElems = idIndexes.map(entity.asInstanceOf[Product].productElement)
+      idElems match
+        case head :: Nil => head.asInstanceOf[ID]
+        case _ => idClassTag.runtimeClass.getDeclaredConstructors().head.newInstance(idElems*).asInstanceOf[ID]
 
     new RepoDefaults[EC, E, ID]:
       def count(using con: DbCon): Long = countQuery.run().head
@@ -103,10 +114,7 @@ object OracleDbType extends DbType:
 
       def delete(entity: E)(using DbCon): Unit =
         deleteById(
-          entity
-            .asInstanceOf[Product]
-            .productElement(idIndex)
-            .asInstanceOf[ID]
+          entityId(entity)
         )
 
       def deleteById(id: ID)(using DbCon): Unit =
@@ -117,9 +125,7 @@ object OracleDbType extends DbType:
 
       def deleteAll(entities: Iterable[E])(using DbCon): BatchUpdateResult =
         deleteAllById(
-          entities.map(e =>
-            e.asInstanceOf[Product].productElement(idIndex).asInstanceOf[ID]
-          )
+          entities.map(entityId)
         )
 
       def deleteAllById(ids: Iterable[ID])(using
@@ -168,9 +174,9 @@ object OracleDbType extends DbType:
               .productIterator
               .toVector
             // put ID at the end
-            val updateValues = entityValues
-              .patch(idIndex, Vector.empty, 1)
-              .appended(entityValues(idIndex))
+            val (idValues, ecValues) = entityValues.zipWithIndex
+              .partition((_, index) => idIndexes.contains(index))
+            val updateValues = ecValues.map(_._1) ++ idValues.map(_._1)
 
             var pos = 1
             for (field, codec) <- updateValues.lazyZip(updateCodecs) do
@@ -189,9 +195,9 @@ object OracleDbType extends DbType:
                 .productIterator
                 .toVector
               // put ID at the end
-              val updateValues = entityValues
-                .patch(idIndex, Vector.empty, 1)
-                .appended(entityValues(idIndex))
+              val (idValues, ecValues) = entityValues.zipWithIndex
+                .partition((_, index) => idIndexes.contains(index))
+              val updateValues = ecValues.map(_._1) ++ idValues.map(_._1)
 
               var pos = 1
               for (field, codec) <- updateValues.lazyZip(updateCodecs) do

--- a/magnum/src/main/scala/com/augustnagro/magnum/PostgresDbType.scala
+++ b/magnum/src/main/scala/com/augustnagro/magnum/PostgresDbType.scala
@@ -17,7 +17,7 @@ object PostgresDbType extends DbType:
       eElemCodecs: Seq[DbCodec[?]],
       ecElemNames: Seq[String],
       ecElemNamesSql: Seq[String],
-      idIndex: Int
+      idIndexes: List[Int]
   )(using
       eCodec: DbCodec[E],
       ecCodec: DbCodec[EC],
@@ -26,40 +26,45 @@ object PostgresDbType extends DbType:
       ecClassTag: ClassTag[EC],
       idClassTag: ClassTag[ID]
   ): RepoDefaults[EC, E, ID] =
-    val idName = eElemNamesSql(idIndex)
+    val idNames = idIndexes.map(eElemNamesSql)
+    val idKeys = idNames.mkString("(", ", ", ")")
     val selectKeys = eElemNamesSql.mkString(", ")
     val ecInsertKeys = ecElemNamesSql.mkString("(", ", ", ")")
 
-    val updateKeys: String = eElemNamesSql
-      .lazyZip(eElemCodecs)
+    val eElemNamesAndCodecs = eElemNamesSql.lazyZip(eElemCodecs)
+    val (idNamesAndCodecs, ecNamesAndCodecs) =
+      eElemNamesAndCodecs.partition((sqlName, _) => idNames.contains(sqlName))
+
+    val idFilter = idKeys + " = " + idCodec.queryRepr
+
+    val updateKeys: String = ecNamesAndCodecs
       .map((sqlName, codec) => sqlName + " = " + codec.queryRepr)
-      .patch(idIndex, Seq.empty, 1)
       .mkString(", ")
 
-    val updateCodecs = eElemCodecs
-      .patch(idIndex, Seq.empty, 1)
-      .appended(idCodec)
-      .asInstanceOf[Seq[DbCodec[Any]]]
+    val updateCodecs =
+      (ecNamesAndCodecs.map(_._2) ++ idNamesAndCodecs.map(_._2))
+        .toSeq
+        .asInstanceOf[Seq[DbCodec[Any]]]
 
     val countSql = s"SELECT count(*) FROM $tableNameSql"
     val countQuery = Frag(countSql, Vector.empty, FragWriter.empty).query[Long]
     val existsByIdSql =
-      s"SELECT 1 FROM $tableNameSql WHERE $idName = ${idCodec.queryRepr}"
+      s"SELECT 1 FROM $tableNameSql WHERE $idFilter"
     val findAllSql = s"SELECT $selectKeys FROM $tableNameSql"
     val findAllQuery = Frag(findAllSql, Vector.empty, FragWriter.empty).query[E]
     val findByIdSql =
-      s"SELECT $selectKeys FROM $tableNameSql WHERE $idName = ${idCodec.queryRepr}"
+      s"SELECT $selectKeys FROM $tableNameSql WHERE $idFilter"
     val findAllByIdSql =
-      s"SELECT $selectKeys FROM $tableNameSql WHERE $idName = ANY(?)"
+      s"SELECT $selectKeys FROM $tableNameSql WHERE $idKeys = ANY(?)"
     val deleteByIdSql =
-      s"DELETE FROM $tableNameSql WHERE $idName = ${idCodec.queryRepr}"
+      s"DELETE FROM $tableNameSql WHERE $idFilter"
     val truncateSql = s"TRUNCATE TABLE $tableNameSql"
     val truncateUpdate =
       Frag(truncateSql, Vector.empty, FragWriter.empty).update
     val insertSql =
       s"INSERT INTO $tableNameSql $ecInsertKeys VALUES (${ecCodec.queryRepr})"
     val updateSql =
-      s"UPDATE $tableNameSql SET $updateKeys WHERE $idName = ${idCodec.queryRepr}"
+      s"UPDATE $tableNameSql SET $updateKeys WHERE $idFilter"
 
     val compositeId = idCodec.cols.distinct.size != 1
     val idFirstTypeName = JDBCType.valueOf(idCodec.cols.head).getName
@@ -67,6 +72,12 @@ object PostgresDbType extends DbType:
     def idWriter(id: ID): FragWriter = (ps, pos) =>
       idCodec.writeSingle(id, ps, pos)
       pos + idCodec.cols.length
+
+    def entityId(entity: E): ID =
+      val idElems = idIndexes.map(entity.asInstanceOf[Product].productElement)
+      idElems match
+        case head :: Nil => head.asInstanceOf[ID]
+        case _ => idClassTag.runtimeClass.getDeclaredConstructors().head.newInstance(idElems*).asInstanceOf[ID]
 
     new RepoDefaults[EC, E, ID]:
       def count(using con: DbCon): Long = countQuery.run().head
@@ -106,10 +117,7 @@ object PostgresDbType extends DbType:
 
       def delete(entity: E)(using DbCon): Unit =
         deleteById(
-          entity
-            .asInstanceOf[Product]
-            .productElement(idIndex)
-            .asInstanceOf[ID]
+          entityId(entity)
         )
 
       def deleteById(id: ID)(using DbCon): Unit =
@@ -121,9 +129,7 @@ object PostgresDbType extends DbType:
 
       def deleteAll(entities: Iterable[E])(using DbCon): BatchUpdateResult =
         deleteAllById(
-          entities.map(e =>
-            e.asInstanceOf[Product].productElement(idIndex).asInstanceOf[ID]
-          )
+          entities.map(entityId)
         )
 
       def deleteAllById(ids: Iterable[ID])(using
@@ -183,9 +189,9 @@ object PostgresDbType extends DbType:
               .productIterator
               .toVector
             // put ID at the end
-            val updateValues = entityValues
-              .patch(idIndex, Vector.empty, 1)
-              .appended(entityValues(idIndex))
+            val (idValues, ecValues) = entityValues.zipWithIndex
+              .partition((_, index) => idIndexes.contains(index))
+            val updateValues = ecValues.map(_._1) ++ idValues.map(_._1)
 
             var pos = 1
             for (field, codec) <- updateValues.lazyZip(updateCodecs) do
@@ -204,9 +210,9 @@ object PostgresDbType extends DbType:
                 .productIterator
                 .toVector
               // put ID at the end
-              val updateValues = entityValues
-                .patch(idIndex, Vector.empty, 1)
-                .appended(entityValues(idIndex))
+              val (idValues, ecValues) = entityValues.zipWithIndex
+                .partition((_, index) => idIndexes.contains(index))
+              val updateValues = ecValues.map(_._1) ++ idValues.map(_._1)
 
               var pos = 1
               for (field, codec) <- updateValues.lazyZip(updateCodecs) do

--- a/magnum/src/main/scala/com/augustnagro/magnum/RepoDefaults.scala
+++ b/magnum/src/main/scala/com/augustnagro/magnum/RepoDefaults.scala
@@ -62,7 +62,7 @@ object RepoDefaults:
         $eElemCodecs,
         ${ Expr(exprs.ecElemNames) },
         ${ Expr.ofSeq(exprs.ecElemNamesSql) },
-        ${ exprs.idIndex }
+        ${ exprs.idIndexes }
       )(using
         $eCodec,
         $ecCodec,

--- a/magnum/src/main/scala/com/augustnagro/magnum/SqliteDbType.scala
+++ b/magnum/src/main/scala/com/augustnagro/magnum/SqliteDbType.scala
@@ -27,7 +27,7 @@ object SqliteDbType extends DbType:
       eElemCodecs: Seq[DbCodec[?]],
       ecElemNames: Seq[String],
       ecElemNamesSql: Seq[String],
-      idIndex: Int
+      idIndexes: List[Int]
   )(using
       eCodec: DbCodec[E],
       ecCodec: DbCodec[EC],
@@ -36,44 +36,54 @@ object SqliteDbType extends DbType:
       ecClassTag: ClassTag[EC],
       idClassTag: ClassTag[ID]
   ): RepoDefaults[EC, E, ID] =
-    val idName = eElemNamesSql(idIndex)
+    val idNames = idIndexes.map(eElemNamesSql)
+    val idKeys = idNames.mkString("(", ", ", ")")
     val selectKeys = eElemNamesSql.mkString(", ")
     val ecInsertKeys = ecElemNamesSql.mkString("(", ", ", ")")
 
-    val updateKeys: String = eElemNamesSql
-      .lazyZip(eElemCodecs)
+    val eElemNamesAndCodecs = eElemNamesSql.lazyZip(eElemCodecs)
+    val (idNamesAndCodecs, ecNamesAndCodecs) =
+      eElemNamesAndCodecs.partition((sqlName, _) => idNames.contains(sqlName))
+
+    val idFilter = idKeys + " = " + idCodec.queryRepr
+
+    val updateKeys: String = ecNamesAndCodecs
       .map((sqlName, codec) => sqlName + " = " + codec.queryRepr)
-      .patch(idIndex, Seq.empty, 1)
       .mkString(", ")
 
-    val updateCodecs = eElemCodecs
-      .patch(idIndex, Seq.empty, 1)
-      .appended(idCodec)
-      .asInstanceOf[Seq[DbCodec[Any]]]
-
+    val updateCodecs =
+      (ecNamesAndCodecs.map(_._2) ++ idNamesAndCodecs.map(_._2))
+        .toSeq
+        .asInstanceOf[Seq[DbCodec[Any]]]
     val insertGenKeys = eElemNamesSql.toArray
 
     val countSql = s"SELECT count(*) FROM $tableNameSql"
     val countQuery = Frag(countSql, Vector.empty, FragWriter.empty).query[Long]
     val existsByIdSql =
-      s"SELECT 1 FROM $tableNameSql WHERE $idName = ${idCodec.queryRepr}"
+      s"SELECT 1 FROM $tableNameSql WHERE $idFilter"
     val findAllSql = s"SELECT * FROM $tableNameSql"
     val findAllQuery = Frag(findAllSql, Vector.empty, FragWriter.empty).query[E]
     val findByIdSql =
-      s"SELECT * FROM $tableNameSql WHERE $idName = ${idCodec.queryRepr}"
+      s"SELECT * FROM $tableNameSql WHERE $idFilter"
     val deleteByIdSql =
-      s"DELETE FROM $tableNameSql WHERE $idName = ${idCodec.queryRepr}"
+      s"DELETE FROM $tableNameSql WHERE $idFilter"
     val truncateSql = s"DELETE FROM $tableNameSql"
     val truncateUpdate =
       Frag(truncateSql, Vector.empty, FragWriter.empty).update
     val insertSql =
       s"INSERT INTO $tableNameSql $ecInsertKeys VALUES (${ecCodec.queryRepr})"
     val updateSql =
-      s"UPDATE $tableNameSql SET $updateKeys WHERE $idName = ${idCodec.queryRepr}"
+      s"UPDATE $tableNameSql SET $updateKeys WHERE $idFilter"
 
     def idWriter(id: ID): FragWriter = (ps, pos) =>
       idCodec.writeSingle(id, ps, pos)
       pos + idCodec.cols.length
+
+    def entityId(entity: E): ID =
+      val idElems = idIndexes.map(entity.asInstanceOf[Product].productElement)
+      idElems match
+        case head :: Nil => head.asInstanceOf[ID]
+        case _ => idClassTag.runtimeClass.getDeclaredConstructors().head.newInstance(idElems*).asInstanceOf[ID]
 
     new RepoDefaults[EC, E, ID]:
       def count(using con: DbCon): Long = countQuery.run().head
@@ -102,10 +112,7 @@ object SqliteDbType extends DbType:
 
       def delete(entity: E)(using DbCon): Unit =
         deleteById(
-          entity
-            .asInstanceOf[Product]
-            .productElement(idIndex)
-            .asInstanceOf[ID]
+          entityId(entity)
         )
 
       def deleteById(id: ID)(using DbCon): Unit =
@@ -117,9 +124,7 @@ object SqliteDbType extends DbType:
 
       def deleteAll(entities: Iterable[E])(using DbCon): BatchUpdateResult =
         deleteAllById(
-          entities.map(e =>
-            e.asInstanceOf[Product].productElement(idIndex).asInstanceOf[ID]
-          )
+          entities.map(entityId)
         )
 
       def deleteAllById(ids: Iterable[ID])(using
@@ -160,9 +165,9 @@ object SqliteDbType extends DbType:
               .productIterator
               .toVector
             // put ID at the end
-            val updateValues = entityValues
-              .patch(idIndex, Vector.empty, 1)
-              .appended(entityValues(idIndex))
+            val (idValues, ecValues) = entityValues.zipWithIndex
+              .partition((_, index) => idIndexes.contains(index))
+            val updateValues = ecValues.map(_._1) ++ idValues.map(_._1)
 
             var pos = 1
             for (field, codec) <- updateValues.lazyZip(updateCodecs) do
@@ -181,9 +186,9 @@ object SqliteDbType extends DbType:
                 .productIterator
                 .toVector
               // put ID at the end
-              val updateValues = entityValues
-                .patch(idIndex, Vector.empty, 1)
-                .appended(entityValues(idIndex))
+              val (idValues, ecValues) = entityValues.zipWithIndex
+                .partition((_, index) => idIndexes.contains(index))
+              val updateValues = ecValues.map(_._1) ++ idValues.map(_._1)
 
               var pos = 1
               for (field, codec) <- updateValues.lazyZip(updateCodecs) do

--- a/magnum/src/main/scala/com/augustnagro/magnum/TableExprs.scala
+++ b/magnum/src/main/scala/com/augustnagro/magnum/TableExprs.scala
@@ -10,5 +10,5 @@ private case class TableExprs(
     eElemNamesSql: Seq[Expr[String]],
     ecElemNames: List[String],
     ecElemNamesSql: Seq[Expr[String]],
-    idIndex: Expr[Int]
+    idIndexes: Expr[List[Int]]
 )

--- a/magnum/src/main/scala/com/augustnagro/magnum/util.scala
+++ b/magnum/src/main/scala/com/augustnagro/magnum/util.scala
@@ -267,7 +267,7 @@ private def tableExprs[EC: Type, E: Type, ID: Type](using
   import quotes.reflect.*
   assertECIsSubsetOfE[EC, E]
 
-  val idIndex = idAnnotIndex[E]
+  val idIndexes = idAnnotIndex[E]
   val table: Expr[Table] =
     DerivingUtil.tableAnnot[E] match
       case Some(table) => table
@@ -317,7 +317,7 @@ private def tableExprs[EC: Type, E: Type, ID: Type](using
             eElemNamesSql,
             ecElemNames,
             ecElemNamesSql,
-            idIndex
+            idIndexes
           )
         case _ =>
           report.errorAndAbort(
@@ -330,19 +330,20 @@ private def tableExprs[EC: Type, E: Type, ID: Type](using
   end match
 end tableExprs
 
-private def idAnnotIndex[E: Type](using q: Quotes): Expr[Int] =
+private def idAnnotIndex[E: Type](using q: Quotes): Expr[List[Int]] =
   import q.reflect.*
   val idAnnot = TypeRepr.of[Id].typeSymbol
-  val index = TypeRepr
+  val indexes = TypeRepr
     .of[E]
     .typeSymbol
     .primaryConstructor
     .paramSymss
     .head
-    .indexWhere(sym => sym.hasAnnotation(idAnnot)) match
-    case -1 => 0
-    case x  => x
-  Expr(index)
+    .zipWithIndex
+    .collect:
+      case (sym, index) if sym.hasAnnotation(idAnnot) => index
+  val nonEmptyIdIndexes = if (indexes.isEmpty) List(0) else indexes
+  Expr(nonEmptyIdIndexes)
 
 private def elemNames[Mels: Type](res: List[String] = Nil)(using
     Quotes

--- a/magnum/src/test/resources/clickhouse/composite-id.sql
+++ b/magnum/src/test/resources/clickhouse/composite-id.sql
@@ -1,0 +1,16 @@
+drop table if exists composite_id;
+
+CREATE TABLE composite_id (
+    first_id Int64 NOT NULL,
+    second_id Int64 NOT NULL,
+    created_at DateTime NOT NULL,
+    user_name String NOT NULL,
+    user_action String NOT NULL
+)
+ENGINE = MergeTree()
+ORDER BY created_at;
+
+INSERT INTO composite_id VALUES
+(1, 1, timestamp '1997-08-15', 'Josh', 'clicked a button'),
+(1, 2, timestamp '1997-08-16', 'Danny', 'opened a toaster'),
+(2, 1, timestamp '1997-08-17', 'Greg', 'ran some QA tests');

--- a/magnum/src/test/resources/h2/composite-id.sql
+++ b/magnum/src/test/resources/h2/composite-id.sql
@@ -1,0 +1,15 @@
+drop table if exists composite_id;
+
+create table composite_id (
+    first_id bigint not null,
+    second_id bigint not null,
+    created_at timestamp with time zone default now() not null,
+    user_name varchar not null,
+    user_action varchar not null,
+    primary key (first_id, second_id)
+);
+
+insert into composite_id values
+(1, 1, timestamp '1997-08-15', 'Josh', 'clicked a button'),
+(1, 2, timestamp '1997-08-16', 'Danny', 'opened a toaster'),
+(2, 1, timestamp '1997-08-17', 'Greg', 'ran some QA tests');

--- a/magnum/src/test/resources/mysql/composite-id.sql
+++ b/magnum/src/test/resources/mysql/composite-id.sql
@@ -1,0 +1,15 @@
+drop table if exists composite_id;
+
+create table composite_id (
+    first_id bigint not null,
+    second_id bigint not null,
+    created_at datetime not null default now(),
+    user_name varchar(200) not null,
+    user_action varchar(200) not null,
+    primary key (first_id, second_id)
+);
+
+insert into composite_id values
+(1, 1, '1997-08-15', 'Josh', 'clicked a button'),
+(1, 2, '1997-08-16', 'Danny', 'opened a toaster'),
+(2, 1, '1997-08-17', 'Greg', 'ran some QA tests');

--- a/magnum/src/test/resources/pg/composite-id.sql
+++ b/magnum/src/test/resources/pg/composite-id.sql
@@ -1,0 +1,15 @@
+drop table if exists composite_id;
+
+create table composite_id (
+    first_id bigint not null,
+    second_id bigint not null,
+    created_at timestamptz not null default now(),
+    user_name text not null,
+    user_action text not null,
+    primary key (first_id, second_id)
+);
+
+insert into composite_id values
+(1, 1, timestamp '1997-08-15', 'Josh', 'clicked a button'),
+(1, 2, timestamp '1997-08-16', 'Danny', 'opened a toaster'),
+(2, 1, timestamp '1997-08-17', 'Greg', 'ran some QA tests');

--- a/magnum/src/test/scala/ClickHouseTests.scala
+++ b/magnum/src/test/scala/ClickHouseTests.scala
@@ -38,6 +38,7 @@ class ClickHouseTests extends FunSuite, TestContainersFixtures:
     val tableDDLs = Vector(
       "clickhouse/car.sql",
       "clickhouse/no-id.sql",
+      "clickhouse/composite-id.sql",
       "clickhouse/person.sql",
       "clickhouse/big-dec.sql",
       "clickhouse/my-time.sql"

--- a/magnum/src/test/scala/H2Tests.scala
+++ b/magnum/src/test/scala/H2Tests.scala
@@ -23,6 +23,7 @@ class H2Tests extends FunSuite:
       "/h2/person.sql",
       "/h2/my-user.sql",
       "/h2/no-id.sql",
+      "/h2/composite-id.sql",
       "/h2/big-dec.sql",
       "/h2/my-time.sql"
     ).map(p => Files.readString(Path.of(getClass.getResource(p).toURI)))

--- a/magnum/src/test/scala/MySqlTests.scala
+++ b/magnum/src/test/scala/MySqlTests.scala
@@ -37,6 +37,7 @@ class MySqlTests extends FunSuite, TestContainersFixtures:
       "/mysql/person.sql",
       "/mysql/my-user.sql",
       "/mysql/no-id.sql",
+      "/mysql/composite-id.sql",
       "/mysql/big-dec.sql",
       "/mysql/my-time.sql"
     ).map(p => Files.readString(Path.of(getClass.getResource(p).toURI)))

--- a/magnum/src/test/scala/OracleTests.scala
+++ b/magnum/src/test/scala/OracleTests.scala
@@ -151,6 +151,31 @@ class OracleTests extends FunSuite, TestContainersFixtures:
           """insert into no_id (created_at, user_name, user_action) values
             |(timestamp '1997-08-17 00:00:00', 'Greg', 'ran some QA tests')""".stripMargin
         )
+        try stmt.execute("drop table composite_id")
+        catch case _ => ()
+        stmt.execute(
+          """create table composite_id (
+            |  first_id number not null,
+            |  second_id number not null,
+            |  created_at timestamp not null,
+            |  user_name varchar2(200) not null,
+            |  user_action varchar2(200) not null,
+            |  primary key (first_id, second_id)
+            |)
+            |""".stripMargin
+        )
+        stmt.execute(
+          """insert into composite_id values
+            |(1, 1, timestamp '1997-08-15 00:00:00', 'Josh', 'clicked a button')""".stripMargin
+        )
+        stmt.execute(
+          """insert into composite_id values
+            |(1, 2, timestamp '1997-08-16 00:00:00', 'Danny', 'opened a toaster')""".stripMargin
+        )
+        stmt.execute(
+          """insert into composite_id values
+            |(2, 1, timestamp '1997-08-17 00:00:00', 'Greg', 'ran some QA tests')""".stripMargin
+        )
         try stmt.execute("drop table big_dec")
         catch case _ => ()
         stmt.execute(

--- a/magnum/src/test/scala/PgTests.scala
+++ b/magnum/src/test/scala/PgTests.scala
@@ -34,6 +34,7 @@ class PgTests extends FunSuite, TestContainersFixtures:
       "/pg/person.sql",
       "/pg/my-user.sql",
       "/pg/no-id.sql",
+      "/pg/composite-id.sql",
       "/pg/big-dec.sql",
       "/pg/my-time.sql"
     ).map(p => Files.readString(Path.of(getClass.getResource(p).toURI)))

--- a/magnum/src/test/scala/SqliteTests.scala
+++ b/magnum/src/test/scala/SqliteTests.scala
@@ -109,6 +109,23 @@ class SqliteTests extends FunSuite:
           |('2024-11-24T22:17:30.000000000Z', 'Danny', 'opened a toaster'),
           |('2024-11-24T22:17:30.000000000Z', 'Greg', 'ran some QA tests');""".stripMargin
       )
+      stmt.execute("drop table if exists composite_id")
+      stmt.execute(
+        """create table composite_id (
+          |  first_id integer not null,
+          |  second_id integer not null,
+          |  created_at text not null,
+          |  user_name text not null,
+          |  user_action text not null,
+          |  primary key (first_id, second_id)
+          |)""".stripMargin
+      )
+      stmt.execute(
+        """insert into composite_id values
+          |(1, 1, '2024-11-24T22:17:30.000000000Z', 'Josh', 'clicked a button'),
+          |(1, 2, '2024-11-24T22:17:30.000000000Z', 'Danny', 'opened a toaster'),
+          |(2, 1, '2024-11-24T22:17:30.000000000Z', 'Greg', 'ran some QA tests')""".stripMargin
+      )
       stmt.execute("drop table if exists big_dec")
       stmt.execute(
         """create table big_dec (

--- a/magnum/src/test/scala/shared/CompositeIdTests.scala
+++ b/magnum/src/test/scala/shared/CompositeIdTests.scala
@@ -1,0 +1,31 @@
+package shared
+
+import com.augustnagro.magnum.*
+import munit.{FunSuite, Location}
+
+import java.time.OffsetDateTime
+
+def compositeIdTests(suite: FunSuite, dbType: DbType, xa: () => Transactor)(
+    using
+    Location,
+    DbCodec[OffsetDateTime]
+): Unit =
+  import suite.*
+
+  @Table(dbType, SqlNameMapper.CamelToSnakeCase)
+  case class CompositeId(
+      @Id firstId: Long,
+      @Id secondId: Long,
+      createdAt: OffsetDateTime,
+      userName: String,
+      userAction: String
+  ) derives DbCodec
+
+  val compositeIdRepo = Repo[CompositeId, CompositeId, (Long, Long)]()
+
+  test("insert CompositeId entities"):
+    xa().connect:
+      val entity = CompositeId(2, 2, OffsetDateTime.now, "Dan", "Fishing")
+      compositeIdRepo.insert(entity)
+      assert(compositeIdRepo.findAll.exists(_.userName == "Dan"))
+end compositeIdTests

--- a/magnum/src/test/scala/shared/SharedTests.scala
+++ b/magnum/src/test/scala/shared/SharedTests.scala
@@ -20,6 +20,7 @@ def sharedTests(suite: FunSuite, dbType: DbType, xa: () => Transactor)(using
   specTests(suite, dbType, xa)
   sqlNameTests(suite, dbType, xa)
   noIdTests(suite, dbType, xa)
+  compositeIdTests(suite, dbType, xa)
   embeddedFragTests(suite, dbType, xa)
   multilineFragTests(suite, dbType, xa)
   bigDecTests(suite, dbType, xa)


### PR DESCRIPTION
Resolve https://github.com/AugustNagro/magnum/issues/57

- Changed `idIndex` in `buildRepoDefaults` and `TableExprs` to support composite IDs
- Updated sql in all DbType to handle composite ids
- Added compositeId tests for all DbType