### PR TITLE
Resolve the sql interpolator's DbCodec[Any] fallback via implicit search

### DIFF
--- a/magnum/src/main/scala/com/augustnagro/magnum/util.scala
+++ b/magnum/src/main/scala/com/augustnagro/magnum/util.scala
@@ -164,9 +164,15 @@ private def summonWriter[T: Type](using Quotes): Expr[DbCodec[T]] =
     )
     .getOrElse:
       report.info(
-        s"Could not find given DbCodec for ${TypeRepr.of[T].show}. Using PreparedStatement::setObject instead."
+        s"Could not find given DbCodec for ${TypeRepr.of[T].widen.show}. Using PreparedStatement::setObject instead."
       )
-      '{ DbCodec.AnyCodec.asInstanceOf[DbCodec[T]] }
+      // Summoned rather than spliced directly, so a user-supplied
+      // DbCodec[Any] in scope takes precedence over DbCodec.AnyCodec.
+      Expr
+        .summon[DbCodec[Any]]
+        .map(codec => '{ $codec.asInstanceOf[DbCodec[T]] })
+        .getOrElse('{ DbCodec.AnyCodec.asInstanceOf[DbCodec[T]] })
+end summonWriter
 
 def batchUpdate[T](values: Iterable[T])(f: T => Update)(using
     con: DbCon

--- a/magnum/src/test/scala/AnyCodecFallbackTests.scala
+++ b/magnum/src/test/scala/AnyCodecFallbackTests.scala
@@ -1,0 +1,37 @@
+import com.augustnagro.magnum.*
+import munit.FunSuite
+import org.h2.jdbcx.JdbcDataSource
+
+import java.math.BigInteger
+import java.sql.{PreparedStatement, ResultSet, Types}
+
+class AnyCodecFallbackTests extends FunSuite:
+
+  lazy val xa: Transactor =
+    val ds = JdbcDataSource()
+    ds.setURL("jdbc:h2:mem:anycodec;DB_CLOSE_DELAY=-1")
+    ds.setUser("sa")
+    ds.setPassword("")
+    Transactor(ds)
+
+  test("interpolating a type with no DbCodec falls back to AnyCodec"):
+    val n = BigInteger.valueOf(42)
+    val res = connect(xa):
+      sql"select $n".query[Long].run().head
+    assertEquals(res, 42L)
+
+  test("a DbCodec[Any] in scope takes precedence over the AnyCodec fallback"):
+    given DbCodec[Any] with
+      val cols: IArray[Int] = IArray(Types.VARCHAR)
+      def readSingle(rs: ResultSet, pos: Int): Any = rs.getString(pos)
+      def readSingleOption(rs: ResultSet, pos: Int): Option[Any] =
+        Option(rs.getString(pos))
+      def writeSingle(a: Any, ps: PreparedStatement, pos: Int): Unit =
+        ps.setString(pos, "intercepted")
+      def queryRepr: String = "?"
+    val n = BigInteger.valueOf(42)
+    val res = connect(xa):
+      sql"select $n".query[String].run().head
+    assertEquals(res, "intercepted")
+
+end AnyCodecFallbackTests


### PR DESCRIPTION
Fixes #152.

When `sql"…"` interpolates a value with no `DbCodec` in scope, `summonWriter` spliced `DbCodec.AnyCodec` directly, so a user-supplied `DbCodec[Any]` could never intercept the silent `setObject` fallback. This resolves the fallback with `Expr.summon[DbCodec[Any]]` instead: with nothing user-supplied in scope, implicit search finds the companion's `AnyCodec` and behaviour is unchanged; a given in lexical scope now takes precedence, so users who want missing codecs to be loud can supply one that throws (or otherwise diverts).

Also widens the type in the info diagnostic, so it names the type (`Could not find given DbCodec for java.math.BigInteger`) rather than the singleton term (`for n`), making the message greppable.

Two new tests in `AnyCodecFallbackTests` (H2, no containers needed) cover both properties: the fallback still applies when no `DbCodec[Any]` is in scope, and an in-scope one wins when present. `magnum/testOnly AnyCodecFallbackTests H2Tests` passes (80 tests); I haven't run the container-backed suites locally.

The derived-codec path in `DbCodec.scala` has the same hardcoded-fallback pattern but a different mechanism (typed `getObject` via `ClassTag`), so I've left it alone here — happy to follow up on it in whatever shape you'd prefer, per the discussion on #152.

---

*Drafted with the assistance of an AI tool (Claude Code); I've reviewed the change and run the tests myself, and will answer follow-ups personally.*
